### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ params = {
     'keywords': keywords,
     'classifiers': [_f for _f in classifiers.split("\n") if _f],
     'url': home_page,
+    'project_urls': {
+        'Source': 'https://github.com/cinemagoer/cinemagoer',
+    },
     'download_url': dwnl_url,
     'scripts': scripts,
     'package_data': {


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)