### PR TITLE
adding 'videos' key to extract movie trailer links

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -696,6 +696,11 @@ class DOMHTMLMovieParser(DOMParserBase):
             key='imdbID',
             extractor=Path('//meta[@property="pageId"]/@content',
                            transform=lambda x: (x or '').replace('tt', ''))
+        ),
+        Rule(
+            key='videos',
+            extractor=Path(foreach='//div[@class="mediastrip_big"]//a',
+                           path='./@href', transform=lambda x: 'http://www.imdb.com' + x)
         )
     ]
 

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -19,6 +19,10 @@ def test_cover_url_if_none_should_be_excluded(ia):
     movie = ia.get_movie('3629794', info=['main'])      # Aslan
     assert 'cover url' not in movie
 
+def test_videos_if_none_should_be_excluded(ia):
+    movie = ia.get_movie('7967312', info=['main'])      # Simple Worker Needed
+    assert 'videos' not in movie
+
 
 def test_movie_directors_should_be_a_list_of_persons(ia):
     movie = ia.get_movie('0133093', info=['main'])      # Matrix


### PR DESCRIPTION
This is useful and incurs no overhead to have link of imdb trailers for movie. (Although it is just the video's page not the video direct link which is not available in imdb)