### PR TITLE
adding parental guide advisory votes

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -2674,6 +2674,27 @@ class DOMHTMLParentsGuideParser(DOMParserBase):
                     )
                 ]
             )
+        ),
+        Rule(
+            key='advisory votes',
+            extractor=Rules(
+                foreach='//section[starts-with(@id, "advisory-")][not(contains(@id, "advisory-spoiler"))]',
+                rules=[
+                    Rule(key='section',
+                         extractor=Path('./@id'),
+                         ),
+                    Rule(key='status',
+                         extractor=Path('.//li[1]//div[contains(@class, "ipl-swapper__content-primary")]//span/text()')
+                         ),
+                    Rule(key='votes',
+                         extractor=Path(
+                             foreach='.//li[1]//span[contains(@class, "ipl-vote-button__details")]',
+                             path='./text()',
+                             transform=lambda x: int(x)
+                         )
+                         )
+                ]
+            )
         )
     ]
 
@@ -2685,6 +2706,23 @@ class DOMHTMLParentsGuideParser(DOMParserBase):
                 if sect and items:
                     data[sect] = items
             del data['advisories']
+
+        if 'advisory votes' in data:
+            advisory_votes = {}
+            for vote in data['advisory votes']:
+                if 'status' not in vote or 'votes' not in vote:
+                    continue
+                advisory_votes[vote['section'][9:]] = {
+                    'votes': {
+                        'None': vote['votes'][0],
+                        'Mild': vote['votes'][1],
+                        'Moderate': vote['votes'][2],
+                        'Severe': vote['votes'][3],
+                    },
+                    'status': vote['status'],
+                }
+            data['advisory votes'] = advisory_votes
+
         return data
 
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -2690,7 +2690,7 @@ class DOMHTMLParentsGuideParser(DOMParserBase):
                          extractor=Path(
                              foreach='.//li[1]//span[contains(@class, "ipl-vote-button__details")]',
                              path='./text()',
-                             transform=lambda x: int(x)
+                             transform=lambda x: int(x.replace(',', ''))
                          )
                          )
                 ]

--- a/tests/test_http_movie_parental_guide.py
+++ b/tests/test_http_movie_parental_guide.py
@@ -10,3 +10,10 @@ def test_movie_certificates_from_parental_guide(ia):
 def test_movie_advisories(ia):
     movie = ia.get_movie('0133093', info=['parents guide'])      # Matrix
     assert any(['Mouse gets shot' in x for x in movie.get('advisory spoiler violence')])
+
+def test_movie_advisory_votes(ia):
+    movie = ia.get_movie('0133093', info=['parents guide'])      # Matrix
+    votes = movie.get('advisory votes')
+    assert votes['nudity']['votes']['Mild'] > 300
+    assert votes['nudity']['status'] == 'Mild'
+    assert votes['profanity']['status'] == 'Moderate'


### PR DESCRIPTION
The new key is named "advisory votes" and a sample value of that is like this:

{'nudity': {'votes': {'None': 0, 'Mild': 6, 'Moderate': 3, 'Severe': 1}, 'status': 'Mild'},
 'violence': {'votes': {'None': 0, 'Mild': 1, 'Moderate': 1, 'Severe': 0}, 'status': 'Moderate'},
 'profanity': {'votes': {'None': 0, 'Mild': 1, 'Moderate': 0, 'Severe': 0}, 'status': 'Mild'},
 'alcohol': {'votes': {'None': 1, 'Mild': 0, 'Moderate': 0, 'Severe': 0}, 'status': 'None'}}