### PR TITLE
Raise exception on resize image

### DIFF
--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -46,6 +46,7 @@ from imdb.Movie import Movie
 from imdb.Person import Person
 from imdb.utils import _tagAttr, re_characterRef, re_nameRef, re_titleRef
 from imdb.utils import TAGS_TO_MODIFY
+from imdb._exceptions import IMDbParserError
 
 
 gettext.textdomain('imdbpy')
@@ -612,7 +613,11 @@ def resizeImage(image, width=None, height=None, crop=None):
 
     regexString = r'https://m.media-amazon.com/images/\w/\w+'
 
-    resultImage = re.findall(regexString, image)[0]
+    try:
+        resultImage = re.findall(regexString, image)[0]
+    except IndexError:
+        raise IMDbParserError('Image url not matched. Original url: "%s"' % (image))
+
     if "@@" in image:
         resultImage += '@'
 

--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -46,7 +46,7 @@ from imdb.Movie import Movie
 from imdb.Person import Person
 from imdb.utils import _tagAttr, re_characterRef, re_nameRef, re_titleRef
 from imdb.utils import TAGS_TO_MODIFY
-from imdb._exceptions import IMDbParserError
+from imdb._exceptions import IMDbError
 
 
 gettext.textdomain('imdbpy')
@@ -608,15 +608,15 @@ def getAKAsInLanguage(movie, lang, _searchedTitle=None):
     return akas
 
 
-def resizeImage(image, width=None, height=None, crop=None):
+def resizeImage(image, width=None, height=None, crop=None, custom_regex=None):
     """Return resized and cropped image url."""
 
-    regexString = r'https://m.media-amazon.com/images/\w/\w+'
+    regexString = custom_regex if custom_regex else r'https://m.media-amazon.com/images/\w/\w+'
 
     try:
         resultImage = re.findall(regexString, image)[0]
     except IndexError:
-        raise IMDbParserError('Image url not matched. Original url: "%s"' % (image))
+        raise IMDbError('Image url not matched. Original url: "%s"' % (image))
 
     if "@@" in image:
         resultImage += '@'


### PR DESCRIPTION
Using the imdb.helpers.resizeImage
In some cases the movie poster/cover url is empty. There is no poster or something else happened to the url.

The resizeImage() fails to find the url with the default regex.

Also allow to provide custom regex for urls.
