### PR TITLE
Fix for issue 395 "'Hangar 10' breaks movie search"

### DIFF
--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -317,7 +317,7 @@ def analyze_title(title, canonical=None, canonicalSeries=None, canonicalEpisode=
         canonicalSeries = canonicalEpisode = canonical
     original_t = title
     result = {}
-    title = title.split(' aka ')[0].strip()
+    title = title.split(' aka ')[0].strip().replace('""', '"')
     year = ''
     kind = ''
     imdbIndex = ''


### PR DESCRIPTION
Remove any extra quotes in title.

This is a fix for [issue 395](https://github.com/cinemagoer/cinemagoer/issues/395)

