### PR TITLE
IMDbURLopener: set User-Agent in retrieve_unicode() #415

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -215,6 +215,7 @@ class IMDbURLopener:
                     'https': self.proxies['http']
                 })
                 handlers.append(proxy_handler)
+            self.set_header("User-Agent", "alberanid/Cinemagoer")
             handlers.append(self.https_handler)
             uopener = build_opener(*handlers)
             uopener.addheaders = list(self.addheaders)


### PR DESCRIPTION
IMDb no longer seems to accept an empty User-Agent for some requests and returns an HTTP-error 405. This patch sets a User-Agent of "alberanid/Cinemagoer", which so far IMDb appears to accept.

Signed-off-by: Nita Vesa <werecatf@outlook.com>