### PR TITLE
Parse Full Credits Page (Fix #424)

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -700,7 +700,8 @@ class IMDbHTTPAccessSystem(IMDbBase):
         return ret
 
     def get_person_filmography(self, personID):
-        return self.get_person_main(personID)
+        cont = self._retrieve(self.urls['person_main'] % personID + 'fullcredits')
+        return self.pProxy.filmo_parser.parse(cont, getRefs=self._getRefs)
 
     def get_person_biography(self, personID):
         cont = self._retrieve(self.urls['person_main'] % personID + 'bio')

--- a/tests/test_http_person_main.py
+++ b/tests/test_http_person_main.py
@@ -7,12 +7,12 @@ def test_person_headshot_should_be_an_image_link(ia):
 
 
 def test_person_producer_is_in_filmography(ia):
-    person = ia.get_person('0000206', info=['main'])    # Keanu Reeves
+    person = ia.get_person('0000206', info=['filmography'])    # Keanu Reeves
     assert 'producer' in person.get('filmography', {})
 
 
 def test_person_filmography_includes_role(ia):
-    person = ia.get_person('0000206', info=['main'])    # Keanu Reeves
+    person = ia.get_person('0000206', info=['filmography'])    # Keanu Reeves
     movies = person.get('filmography', {}).get('actor', {})
     assert 'John Wick' in [str(movie.currentRole) for movie in movies]
 
@@ -53,14 +53,23 @@ def test_person_imdb_index_should_be_a_roman_number(ia):
 
 
 def test_person_should_have_filmography(ia):
-    person = ia.get_person('0000210', info=['main'])    # Julia Roberts
+    person = ia.get_person('0000210', info=['filmography'])    # Julia Roberts
     filmoset = set(['actress', 'producer', 'soundtrack'])
     assert filmoset.issubset(set(person.get('filmography', {}).keys()))
 
 
 def test_person_filmography_should_contain_movies(ia):
-    person = ia.get_person('0000210', info=['main'])    # Julia Roberts
-    assert len(person.get('filmography', {}).get('actress')) >= 15
+    person = ia.get_person('0000210', info=['filmography'])    # Julia Roberts
+    assert len(person.get('filmography', {}).get('actress')) >= 20
+
+
+def test_person_filmography_should_contain_many_roles(ia):
+    person = ia.get_person('0000110', info=['filmography'])    # Kenneth Branagh
+    filmography = person.get('filmography', {})
+    assert len(filmography) > 9
+    assert len(filmography.get('actor')) >= 70
+    assert len(filmography.get('writer')) >= 9
+    assert len(filmography.get('self')) >= 150
 
 
 def test_person_imdb_index_if_none_should_be_excluded(ia):


### PR DESCRIPTION
A possible fix for #424. 

Potential issues:

 * `filmography` is not retrieved with `main` anymore. It could be mitigated by changing this new logic to something like `"full_filmography"` but I'm not sure what makes the most sense. 
 * The `notes` portion of the film rules is not yet migrated (wasn't sure of a good example)
 * I was guessing on a lot of this stuff. Very open to suggestions. 