### PR TITLE
Fix plot field in plotsummary page

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -890,16 +890,12 @@ class DOMHTMLPlotParser(DOMParserBase):
         Rule(
             key='plot',
             extractor=Rules(
-                foreach='//ul[@id="plot-summaries-content"]/li',
+                foreach='//div[@data-testid="sub-section-summaries"]//li',
                 rules=[
                     Rule(
                         key='plot',
-                        extractor=Path('./p//text()')
+                        extractor=Path('.//text()')
                     ),
-                    Rule(
-                        key='author',
-                        extractor=Path('.//div[@class="author-container"]//a/text()')
-                    )
                 ],
                 transform=_process_plotsummary
             )


### PR DESCRIPTION
The `plotsummary` has been changed and the previous selector didn't work. The author field has been deleted from the page apparently.