### PR TITLE
Extract StarList

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -290,6 +290,13 @@ class DOMHTMLMovieParser(DOMParserBase):
             extractor=Path('//meta[@name="title"]/@content',
                            transform=lambda x: analyze_og_title(x).get('title'))
         ),
+        Rule(
+            key="stars",
+            extractor=Path(
+                foreach='//div[@class="titlereference-overview-section" and '
+                        'contains(text(), "Stars:")]/ul/li[1]/a',
+                path='./text()')
+        ),
 
         # parser for misc sections like 'casting department', 'stunts', ...
         Rule(


### PR DESCRIPTION
Cast can be listed in any order (alphabetic, for instance) and a "star" list can be useful. Moreover, this info is already available in the webpage retrieved by the "main" infoset.