### PR TITLE
#439: fix parsing of critics reviews page

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -1647,11 +1647,11 @@ class DOMHTMLCriticReviewsParser(DOMParserBase):
     rules = [
         Rule(
             key='metascore',
-            extractor=Path('//div[@class="metascore_wrap"]/div/span//text()')
+            extractor=Path('//*[@data-testid="critic-reviews-title"]/div/text()')
         ),
         Rule(
             key='metacritic url',
-            extractor=Path('//div[@class="article"]/div[@class="see-more"]/a/@href')
+            extractor=Path('//*[@data-testid="critic-reviews-title"]/div[2]/div[2]/a/@href')
         )
     ]
 


### PR DESCRIPTION
The metascore could also be parsed on the main page. I tried that but when you ask for `'main', 'critic reviews'` you get an error because of the duplicate key. I didn't want to remove the parsing of the metascore from 'critic reviews' in case a user does not also request the main data.