### PR TITLE
XPath fixes for season episodes parser

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -2161,7 +2161,7 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
         ),
         Rule(
             key='_current_season',
-            extractor=Path('//li[@data-testid="tab-season-entry"][@aria-selected="true"]/text()')
+            extractor=Path('//a[@data-testid="tab-season-entry"][contains(@class, "ipc-tab--active")]/text()')
         ),
         Rule(
             key='episodes',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -2155,7 +2155,7 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
         Rule(
             key='_seasons',
             extractor=Path(
-                foreach='//li[@data-testid="tab-season-entry"]',
+                foreach='//a[@data-testid="tab-season-entry"]',
                 path='./text()'
             )
         ),


### PR DESCRIPTION
Built on top of a previous [PR 503](https://github.com/cinemagoer/cinemagoer/pull/503)
This PR includes the latest commits from main and an additional XPath fix. 

I was able to get the series code from the [docs](https://cinemagoer.readthedocs.io/en/latest/usage/series.html#series) to work as expected

```py
series = ia.get_movie('0389564')
ia.update(series, "episodes")
assert len(series["episodes"]) > 0
assert series["number of episodes"] > 0
```