### PR TITLE
fix: corrected year and kind detection

### DIFF
--- a/imdb/parser/http/searchMovieParser.py
+++ b/imdb/parser/http/searchMovieParser.py
@@ -66,25 +66,25 @@ class DOMHTMLSearchMovieParser(DOMParserBase):
                 rules=[
                     Rule(
                         key='link',
-                        extractor=Path('.//a[@class="ipc-metadata-list-summary-item__t"]/@href',
+                        extractor=Path('.//a[contains(@class, "ipc-metadata-list-summary-item__t")]/@href',
                                        reduce=reducers.first)
                     ),
                     Rule(
                         key='title',
-                        extractor=Path('.//a[@class="ipc-metadata-list-summary-item__t"]/text()')
+                        extractor=Path('.//a[contains(@class, "ipc-metadata-list-summary-item__t")]/text()')
                     ),
                     Rule(
                         key='year',
-                        extractor=Path('.//span[@class="ipc-metadata-list-summary-item__li"]/text()',
+                        extractor=Path('.//span[contains(@class, "ipc-metadata-list-summary-item__li")]/text()',
                                        reduce=reducers.first)
                     ),
                     Rule(
                         key='kind',
-                        extractor=Path('(.//span[@class="ipc-metadata-list-summary-item__li"])[2]/text()')
+                        extractor=Path('(.//span[contains(@class, "ipc-metadata-list-summary-item__li")])[2]/text()')
                     ),
                     Rule(
                         key='cover url',
-                        extractor=Path('.//img[@class="ipc-image"]/@src')
+                        extractor=Path('.//img[contains(@class, "ipc-image")]/@src')
                     )
                 ],
                 transform=process_title


### PR DESCRIPTION
IMDb now seems to add multiple CSS classes to the corresponding class attributes, switched from `@class="X"` to `contains(@class, "X")` to address this